### PR TITLE
Nicer error page

### DIFF
--- a/Commencement.Mvc/Controllers/HomeController.cs
+++ b/Commencement.Mvc/Controllers/HomeController.cs
@@ -59,6 +59,11 @@ namespace Commencement.Controllers
             // is student registered for the current term, if term not open?
             var term = TermService.GetCurrent();
             var student = GetCurrentStudent();
+            if (student == null)
+            {
+                return this.RedirectToAction<ErrorController>(a => a.NotFound());
+            }
+
             ViewBag.StudentName = student.FirstName;
 
             // check for a current registration, there should only be one


### PR DESCRIPTION
If no student found for the current term, go to nice error page.
This can happen once a student has graduated and is not in banner for the current term.
Can also happen if the student doesn't have the minimum units.
If they have the units, but have already walked, eventually they would get a different error page.
Closes #125 