### PR TITLE
Increase the Report Adapter timeout

### DIFF
--- a/Commencement.Mvc/ReportDataSets/CommencementDataSet_SpecialNeedsReport.Designer.cs
+++ b/Commencement.Mvc/ReportDataSets/CommencementDataSet_SpecialNeedsReport.Designer.cs
@@ -1180,6 +1180,7 @@ namespace Commencement.Mvc.ReportDataSets.CommencementDataSet_SpecialNeedsReport
                 this.Adapter.SelectCommand.Parameters[2].Value = global::System.DBNull.Value;
             }
             CommencementDataSet_SpecialNeedsReport.usp_SpecialNeedsReportDataTable dataTable = new CommencementDataSet_SpecialNeedsReport.usp_SpecialNeedsReportDataTable();
+            this.Adapter.SelectCommand.CommandTimeout = 300;
             this.Adapter.Fill(dataTable);
             return dataTable;
         }


### PR DESCRIPTION
for the SpecialNeeds report to 300 seconds (default is 30)